### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ ARG     SOURCE_PREFIX="/opt/src"
 
 RUN mkdir -p ${SOURCE_PREFIX}
 
+#Nvidia Public GPG Key
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 # Get dependencies
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Without NVIDIA GPG Key update, it throws out an error :"W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC"